### PR TITLE
Constraint handler

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -24,15 +24,21 @@ nodeList.append( mc.createNode("multMatrix", n="multMatrix4", skipSelect = True)
 # (...)
 ```
 
-## why the use of openMaya for selection?
+## why the use of openMaya for selection instead of mc.ls(sl=True)?
 
 > openMaya's `MSelectionList` returns a pointer to the DG/DAG object, which allows me to rename a node without having to worry about reflecting the name change elsewhere in the other variables or lists
+>
+> it's less relevant here because of the runtime-only nature of the script (i.e. states aren't important or remembered between runs), but it's more of a force of habit i'd like to keep as much as i can
 
 ## why not use openMaya to create nodes?
 
 > this is an area i'm still very unfamiliar with, but as far as i understand: changes to the DAG/DG (the scene) through openMaya is direct and does not write to the undo queue. there are specific functions to make the commands to be registered in maya's history queue, but that is an undertaking i would like to undertake in a proper plugin project rather than do it here
 >
 > so the use of openMaya has mostly been about handling objects in lists and querying attributes or data (i'm reading there are even functions like querying the closest point on a curve without resorting to making a node in the scene for that, so that opens the possibility for openMaya-based parametric models)
+
+## why is the script output `nodeList` in a pre-enumerated list? why not list.append()?
+
+> the aim of the output is to be human-editable, so having each item in the nodeList be directly assigned an index means that i could edit or delete values in an index, and the rest of the list are still maintained. this is important for further commands below using items in the `nodeList` for inputs
 
 ## why did you createNode a curve, assign it two points, then rebuild the curve with the actual points later?
 

--- a/notes.md
+++ b/notes.md
@@ -33,3 +33,34 @@ nodeList.append( mc.createNode("multMatrix", n="multMatrix4", skipSelect = True)
 > this is an area i'm still very unfamiliar with, but as far as i understand: changes to the DAG/DG (the scene) through openMaya is direct and does not write to the undo queue. there are specific functions to make the commands to be registered in maya's history queue, but that is an undertaking i would like to undertake in a proper plugin project rather than do it here
 >
 > so the use of openMaya has mostly been about handling objects in lists and querying attributes or data (i'm reading there are even functions like querying the closest point on a curve without resorting to making a node in the scene for that, so that opens the possibility for openMaya-based parametric models)
+
+## why did you createNode a curve, assign it two points, then rebuild the curve with the actual points later?
+
+```py
+curveTransformShape = [None,None]
+curveTransformShape[0] = mc.createNode('transform', n=curveTransform)
+curveTransformShape[1] = mc.createNode('nurbsCurve', n=curveShape, p=curveTransformShape[0])
+mc.setAttr(curveTransformShape[1]+'.cc', 3,1,0,False,3,(0,0,0,1,1,1),6,4,(0,0,0),(0,0,0),(0,0,0),(0,0,0), type="nurbsCurve")
+	# this is a cubic curve with two edit points at (0,0,0), applied temporarily to make it a valid cubic curve
+mc.curve(curveTransformShape[0], replace=True, ep=jointAsEPs, d=3)
+```
+
+> if i were to createNode a nurbsCurve without giving it any points, then use curve(replace=True) with a desired curve, maya crashes because there is no valid curve data being held in that shape node
+>
+> also methodologically speaking: yes it would make sense for the curve data to be copied and applied directly (i'm doing this for curve controller shapes), but in specifc cases like drawing a curve that passes through a joint chain (especially for splineIK), using the curve() command would be much easier because the command has a flag that accepts edit points (points on a curve) instead of control vertices (points defining a curve that may not be on the curve itself)
+>
+> directly applying curve data can only work with control vertices, so that is a solution that does not fit all tasks that would require passing a curve through specific points in space
+>
+> admittedly mathematical curve definitions is one of the many major gaps in my knowledge, and i am really leaning hard on maya's implementations to solve going between control vertices and edit points. i do wish to be able to get a handle on this one day, so that i could do a platform/engine-agnostic implementation across more programs and environments
+
+## why is the script not fully characterising constraint nodes? where are the connection commands for it?
+
+> i'm using the respective creation commands to create constraint nodes and connections, as this is too many to keep track of.
+>
+> in addition, the scope of the constraint handler is greatly reduced in order to manage scope, as in most cases the constraints are created then forgotten (i.e. it only deals with one driver/target object and one driven/constraint object). so this script doesn't do much more than enumerating the single creation command, although this isn't set in stone and may be added on in the future
+
+## why is everything in a singleton script?!
+
+> i'm looking to run this either in the script editor or as a shelf command, and i want to minimise having to deal with relative script imports (either in maya's project environment or the default environment)
+>
+> it's an extremely long read, but it's the only simplest way i can think of that would be a copy-paste-and-run solution

--- a/notes/mayaConstraintNodes.md
+++ b/notes/mayaConstraintNodes.md
@@ -1,0 +1,225 @@
+# constraint nodes in maya and differences
+
+## the commands
+
+common flags in commands:
+
+- `offset`
+	- attributes affected (this node):
+- `maintainOffset`
+	- attributes affected (this node):
+- `skip`
+	- or `skipTranslate` and `skipRotate` for `mc.parentConstraint()`
+	- skips making connection to specific axes on driven/child transform object
+	- attributes affected (this node), where applicable:
+		- `.constraintTranslate` ; .x .y .z
+		- `.constraintRotate` ; .x .y .z
+		- `.constraintScale` ; .x .y .z
+- `targetList`
+	- returns names of targets/drivers/parents
+- `remove` and/or repeated use of command with same child/driven
+	- removes parent/driver from `.target[]` in constraint node
+	- repeated use of creation command adds parent/driver to next index of `.target[]`
+	- attributes affected (this node):
+		- `.target[n]` and all its subattributes
+		- to check: user-defined attribute tied to `.target[n].targetWeight`
+
+
+## the nodes
+> Although the all the constraint nodes inherit from transform, they do not actively use any of the attributes from transform. 
+
+common attributes connected by command:
+- `target[n]` and its subattributes
+	- to find upstream target(s):
+		- query `target[n].targetParentMatrix`
+		- or use `targetList` in command query mode
+	- driver/parent's attributes will be connected to this attribute
+	- if multiple parents or another parent is added by same command, new additions are connected on the next empty slots
+- `constraint` attributes
+	- to find downstream driven transform:
+		- query `.constraintParentInverseMatrix`
+	- driven/child's transforms will be driven by these according to type of constraint
+
+attributes to keep note for recreation command:
+- `offset`
+	- adjusted by constraint creation command with `maintain offset` flag
+	- `parentConstaint` does not have this
+- `target[n].targetWeight`
+	- connected and controlled by driver, but by default it's connected to a user-defined attribute on self, automatically created by the constraint command
+- attributes pre-evaluated by constraint command (e.g. when maintain offset is requested):
+	- needs checking...
+- `restTranslate`, `restRotate`, `restScale`
+	- needs checking...
+- `aimVector`, `upVector`, `worldUpMatrix`, `worldUpType`, `worldUpVector`
+	- just for aimConstraint
+	- needs checking...
+
+## poleVectorConstraint
+
+> poleVectorConstraint is a variation on a pointConstraint that is designed explicitly to constrain the pole vector of an ikRPsolver ikHandle to follow one or more target objects
+- .pivotSpace
+
+### attributes
+
+**attributes pre-evaluated by maintain offsets**
+
+needs checking...
+
+**constraints**
+
+|attr/constraint|parent|aim|orient|point|scale|poleVector|
+|:-|:-:|:-:|:-:|:-:|:-:|:-:|
+|.aimVector [x,y,z]					| |O| | | | |
+|.upVector [x,y,z]					| |O| | | | |
+|.lastTargetRotate [x,y,z]			|O| |O| | | |
+|.offset [x,y,z]					| |O|O|O|O|O|
+|.restTranslate [x,y,z]				|O| | |O| |O|
+|.restRotate [x,y,z]				|O|O|O| | | |
+|.restScale [x,y,z]					| | | | |O| |
+|.inverseScale [x,y,z]				| |O|O| | | |
+|.constraintParentInverseMatrix		|O|O|O|O|O|O|
+|.constraintTranslate [x,y,z]		|O|O| | | | |
+|.constraintOffsetPolarity			| | | |O| |O|
+|.constraintRotate [x,y,z]			|O| |O| | | |
+|.constraintRotateOrder				|O|O|O| | | |
+|.constraintRotatePivot [x,y,z]		|O|O| |O| |O|
+|.constraintJointOrient [x,y,z]		|O|O|O| | | |
+|.constraintRotateTranslate [x,y,z]	|O|O| |O| |O|
+|.constraintScale [x,y,z]			| | | | |O| |
+|.constraintScaleCompensate			| | | | |O| |
+
+**targets**
+
+|attr/constraint|parent|aim|orient|point|scale|poleVector|
+|:-|:-:|:-:|:-:|:-:|:-:|:-:|
+|.target[n]									|O|O|O|O|O|O|
+|.target[].targetWeight						|O|O|O|O|O|O|
+|.target[].targetParentMatrix				|O|O|O|O|O|O|
+|.target[].targetRotateCached [x,y,z]		|O| |O| | | |
+|.target[].targetTranslate [x,y,z]			|O|O| |O| |O|
+|.target[].targetRotatePivot [x,y,z]		|O|O| |O| |O|
+|.target[].targetRotateTranslate [x,y,z]	|O|O| |O| |O|
+|.target[].targetOffsetTranslate [x,y,z]	|O| | | | | |
+|.target[].targetRotate [x,y,z]				|O| |O| | | |
+|.target[].targetRotateOrder				|O| |O| | | |
+|.target[].targetJointOrient [x,y,z]		|O| |O| | | |
+|.target[].targetOffsetRotate [x,y,z]		|O| | | | | |
+|.target[].targetScaleCompensate			|O| | | | | |
+|.target[].targetInverseScale [x,y,z]		|O| | | | | |
+|.target[].targetScale [x,y,z]				|O| | | |O| |
+
+**other attributes**
+
+|attr/constraint|parent|aim|orient|point|scale|poleVector|
+|:-|:-:|:-:|:-:|:-:|:-:|:-:|
+|.interpCache							|O| |O| | | |
+|.interpType							|O| | | | | |
+|.rotationDecompositionTarget [x,y,z]	|O| | | | | |
+|.useDecompositionTarget				|O| | | | | |
+|.scaleCompensate						| |O|O| | | |
+|.useOldOffsetCalculation				| |O|O| | | |
+|.worldUpMatrix							| |O| | | | |
+|.worldUpType							| |O| | | | |
+|.worldUpVector [x,y,z]					| |O| | | | |
+
+### parentConstraint
+- .constraintJointOrient [x,y,z]
+- .constraintParentInverseMatrix
+- .constraintRotate [x,y,z]
+- .constraintRotateOrder
+- .constraintRotatePivot [x,y,z]
+- .constraintRotateTranslate [x,y,z]
+- .constraintTranslate [x,y,z]
+- .interpCache
+- .interpType
+- .lastTargetRotate [x,y,z]
+- .restRotate [x,y,z]
+- .restTranslate [x,y,z]
+- .rotationDecompositionTarget [x,y,z]
+- .target
+	- .targetParentMatrix
+	- .targetWeight
+	- .targetRotateCached [x,y,z]
+	- .targetTranslate [x,y,z]
+	- .targetRotatePivot [x,y,z]
+	- .targetRotateTranslate [x,y,z]
+	- .targetOffsetTranslate [x,y,z]
+	- .targetRotate [x,y,z]
+	- .targetRotateOrder
+	- .targetJointOrient [x,y,z]
+	- .targetOffsetRotate [x,y,z]
+	- .targetScaleCompensate
+	- .targetInverseScale [x,y,z]
+	- .targetScale [x,y,z]
+- .useDecompositionTarget
+
+### aimConstraint
+- .aimVector [x,y,z]
+- .scaleCompensate
+- .offset [x,y,z]
+- .constraintJointOrient [x,y,z]
+- .constraintParentInverseMatrix
+- .constraintRotateOrder
+- .constraintRotatePivot [x,y,z]
+- .constraintRotateTranslate [x,y,z]
+- .constraintTranslate [x,y,z]
+- .inverseScale [x,y,z]
+- .restRotate [x,y,z]
+- .target
+	- .targetTranslate [x,y,z]
+	- .targetRotatePivot [x,y,z]
+	- .targetRotateTranslate [x,y,z]
+	- .targetParentMatrix
+	- .targetWeight
+- .upVector [x,y,z]
+- .useOldOffsetCalculation
+- .worldUpMatrix
+- .worldUpType
+- .worldUpVector [x,y,z]
+
+### orientConstraint
+- .scaleCompensate
+- .offset [x,y,z]
+- .constraintJointOrient [x,y,z]
+- .constraintParentInverseMatrix
+- .constraintRotate [x,y,z]
+- .constraintRotateOrder
+- .interpCache
+- .lastTargetRotate [x,y,z]
+- .inverseScale [x,y,z]
+- .restRotate [x,y,z]
+- .target
+	- .targetRotate [x,y,z]
+	- .targetRotateOrder
+	- .targetJointOrient [x,y,z]
+	- .targetParentMatrix
+	- .targetWeight
+	- .targetRotateCached [x,y,z]
+- .useOldOffsetCalculation
+
+### pointConstraint
+- .offset [x,y,z]
+- .constraintOffsetPolarity
+- .constraintParentInverseMatrix
+- .constraintRotatePivot [x,y,z]
+- .constraintRotateTranslate [x,y,z]
+- .constraintTranslate [x,y,z]
+- .restTranslate [x,y,z]
+- .target
+	- .targetTranslate [x,y,z]
+	- .targetRotatePivot [x,y,z]
+	- .targetRotateTranslate [x,y,z]
+	- .targetParentMatrix
+	- .targetWeight
+
+### scaleConstraint
+- .offset [x,y,z]
+- .constraintParentInverseMatrix
+- .constraintScale [x,y,z]
+- .constraintScaleCompensate
+- .restScale [x,y,z]
+- .target
+	- .targetScale [x,y,z]
+	- .targetParentMatrix
+	- .targetWeight
+

--- a/notes/mayaConstraintNodes.md
+++ b/notes/mayaConstraintNodes.md
@@ -5,9 +5,15 @@
 common flags in commands:
 
 - `offset`
+	- add a numeric offset relative to the result constraint
+	- does not exist on `parentConstraint`
 	- attributes affected (this node):
+		- `offset`; .x .y .z
 - `maintainOffset`
+	- adds a numeric offset to maintain its original transfrom prior to constaining
+	- does not exist on `parentConstraint`
 	- attributes affected (this node):
+		- `offset`; .x .y .z
 - `skip`
 	- or `skipTranslate` and `skipRotate` for `mc.parentConstraint()`
 	- skips making connection to specific axes on driven/child transform object
@@ -15,8 +21,6 @@ common flags in commands:
 		- `.constraintTranslate` ; .x .y .z
 		- `.constraintRotate` ; .x .y .z
 		- `.constraintScale` ; .x .y .z
-- `targetList`
-	- returns names of targets/drivers/parents
 - `remove` and/or repeated use of command with same child/driven
 	- removes parent/driver from `.target[]` in constraint node
 	- repeated use of creation command adds parent/driver to next index of `.target[]`
@@ -24,6 +28,14 @@ common flags in commands:
 		- `.target[n]` and all its subattributes
 		- to check: user-defined attribute tied to `.target[n].targetWeight`
 
+queries:
+- `targetList`
+	- returns names of targets/drivers/parents
+- `weightAliasList`
+	- returns connection to attribute that's connected to the target's `weight` attribute
+	- WARNING: this will also return the attribute connected to it coming from another node, but without the name of the node.
+		- **DO NOT USE THIS TO QUERY TRUE CONNECTIONS.**
+	- to properly check what's connected to `targetWeight`: `mc.listConnections()` on the attribute, and see if it originates from another node
 
 ## the nodes
 > Although the all the constraint nodes inherit from transform, they do not actively use any of the attributes from transform. 
@@ -40,43 +52,111 @@ common attributes connected by command:
 		- query `.constraintParentInverseMatrix`
 	- driven/child's transforms will be driven by these according to type of constraint
 
-attributes to keep note for recreation command:
+attributes of note:
 - `offset`
 	- adjusted by constraint creation command with `maintain offset` flag
 	- `parentConstaint` does not have this
 - `target[n].targetWeight`
 	- connected and controlled by driver, but by default it's connected to a user-defined attribute on self, automatically created by the constraint command
-- attributes pre-evaluated by constraint command (e.g. when maintain offset is requested):
-	- needs checking...
 - `restTranslate`, `restRotate`, `restScale`
-	- needs checking...
-- `aimVector`, `upVector`, `worldUpMatrix`, `worldUpType`, `worldUpVector`
-	- just for aimConstraint
-	- needs checking...
+	- activated by `enableRestPosition`
+		- https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/Nodes/constraint.html
+	- value assigned to driven transforms when all other weights are zero
+- `aimVector`, `upVector`, `worldUpType`, `worldUpMatrix`, `worldUpVector`
+	- just for `aimConstraint`
+	- defines the normal vector guide of a foward vector aim
+	- see: https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/Nodes/aimConstraint.html
 
 ## poleVectorConstraint
 
 > poleVectorConstraint is a variation on a pointConstraint that is designed explicitly to constrain the pole vector of an ikRPsolver ikHandle to follow one or more target objects
-- .pivotSpace
+
+# scope reduction
+
+- manually recording all changed values would be overkill, considering most of these values are enumerated according to the transforms involved
+- evaluating actually "user-defined" `dynamic attributes` would be messy as the creation command makes their own "user-defined" attributes.
+	- the only thing to monitor is where the target weight is connected to. if connected to self.name_W0, leave it as it is. otherwise make the command to connect to it 
+	- (during the rigging process) it'd make more sense to put `dynamic attributes` elsewhere, either on controls or a `network` node
+- where applicable: enable rest will be always on, as a means to define a zero state.
+	- if this is disabled, the driven/constrained object will stop at wherever it was last at when weights are set to zero
+	- this is unpredictable, and controlling through this attribute does not account for other transforms not covered by the constraints
+	- (during the rigging process) the ideal case is to use constraints on a downstream driver, and then blend between this result and the other controllers
+- while every `constraint` node contains a transform (due to constraints being a subclass of the transform node), the transform and its connections will be ignored
+	- (during the rigging process) use a `transform` node or directly make a transform matrix `composeMatrix`, to make things more explicit on the scene hierachy and the node editor. also as a means to survive a deletion request/action of the constraint
+
+the `aimConstraint` node will be covered for the sake of completion, although consider using `aimMatrix` first, especially if most of the rig is already maths and matrix driven in the first place
+
+## creation command flags
+
+query flags require `q=True`
+
+**common flags**
+
+|flag|sN|flag type|parent|aim|orient|point|scale|poleVector|
+|:-|:-|:-|:-:|:-:|:-:|:-:|:-:|:-:|
+|name |`n`|query, create, edit					|O|O|O|O|O|O|
+|offset|`o`| query, create, edit				| |O|O|O|O| |
+|layer |`l`|create, edit						|O|O|O|O|O|O|
+|maintainOffset |`mo`|create					|O|O|O|O|O| |
+|remove |`rm`|edit								|O|O|O|O|O|O|
+|targetList |`tl`|query							|O|O|O|O|O|O|
+|weight = 1.0 |`w`|query, create, edit			|O|O|O|O|O|O|
+|weightAliasList |`wal`|query					|O|O|O|O|O|O|
+|skipRotate |`sr`|create, multiuse				|O| | | | | |
+|skipTranslate |`st`|create, multiuse			|O| | | | | |
+|skip|`sk`| create, edit, multiuse				| |O|O|O|O| |
+
+**specific flags**
+
+
+|flag|sN|flag type|parent|aim|orient|point|scale|poleVector|
+|:-|:-|:-|:-:|:-:|:-:|:-:|:-:|:-:|
+|scaleCompensate|`sc`|create, edit				| | | | |O| |
+|createCache |`cc`|edit							|O| |O| | | |
+|deleteCache |`dc`|edit							|O| |O| | | |
+|decompRotationToChild |`dr`|create				|O| | | | | |
+|aimVector|`aim`| query, create, edit			| |O| | | | |
+|upVector|`u`| query, create, edit				| |O| | | | |
+|worldUpObject|`wuo`| query, create, edit		| |O| | | | |
+|worldUpType|`wut`| query, create, edit			| |O| | | | |
+|worldUpVector|`wu`| query, create, edit		| |O| | | | |
 
 ### attributes
 
-**attributes pre-evaluated by maintain offsets**
+**attributes pre-evaluated by command**
 
-needs checking...
+- `.offset` <- from maintain offset flag
+	- set `maintainOffset` boolean if this value is not zero/default
+- rest positions `restTranslate`, `restRotate`, `restScale`
+	- set `enableRestPosition` boolean if this value is not zero/default
+
+**dynamic attributes and weightALiasList**
+
+when a constraint is made, the command automatically makes a dynamic attribute connected to the target's weight attribute
+
+this is done because in the attribute editor, the targets are not exposed and the only way to control a target is though this dynamic attribute
+
+the node editor will still expose everything on the target's side, but it appears that maya would like to manage this for the user as much as it can (e.g. to add a second target or more, the command is run on the selection including the new target(s) and the existing driven object)
+
 
 **constraints**
 
-|attr/constraint|parent|aim|orient|point|scale|poleVector|
+|attribute|parent|aim|orient|point|scale|poleVector|
 |:-|:-:|:-:|:-:|:-:|:-:|:-:|
 |.aimVector [x,y,z]					| |O| | | | |
 |.upVector [x,y,z]					| |O| | | | |
+|.worldUpMatrix						| |O| | | | |
+|.worldUpType						| |O| | | | |
+|.worldUpVector [x,y,z]				| |O| | | | |
 |.lastTargetRotate [x,y,z]			|O| |O| | | |
+|.inverseScale [x,y,z]				| |O|O| | | |
+| ------- |parent|aim|orient|point|scale|poleVector|
 |.offset [x,y,z]					| |O|O|O|O|O|
+|.lockOutput						|O|O|O|O|O|O|
+|.enableRestPosition				|O|O|O|O|O|O|
 |.restTranslate [x,y,z]				|O| | |O| |O|
 |.restRotate [x,y,z]				|O|O|O| | | |
 |.restScale [x,y,z]					| | | | |O| |
-|.inverseScale [x,y,z]				| |O|O| | | |
 |.constraintParentInverseMatrix		|O|O|O|O|O|O|
 |.constraintTranslate [x,y,z]		|O|O| | | | |
 |.constraintOffsetPolarity			| | | |O| |O|
@@ -90,37 +170,40 @@ needs checking...
 
 **targets**
 
-|attr/constraint|parent|aim|orient|point|scale|poleVector|
+|attribute|parent|aim|orient|point|scale|poleVector|
 |:-|:-:|:-:|:-:|:-:|:-:|:-:|
 |.target[n]									|O|O|O|O|O|O|
 |.target[].targetWeight						|O|O|O|O|O|O|
 |.target[].targetParentMatrix				|O|O|O|O|O|O|
-|.target[].targetRotateCached [x,y,z]		|O| |O| | | |
 |.target[].targetTranslate [x,y,z]			|O|O| |O| |O|
-|.target[].targetRotatePivot [x,y,z]		|O|O| |O| |O|
-|.target[].targetRotateTranslate [x,y,z]	|O|O| |O| |O|
-|.target[].targetOffsetTranslate [x,y,z]	|O| | | | | |
 |.target[].targetRotate [x,y,z]				|O| |O| | | |
-|.target[].targetRotateOrder				|O| |O| | | |
-|.target[].targetJointOrient [x,y,z]		|O| |O| | | |
+|.target[].targetScale [x,y,z]				|O| | | |O| |
+|.target[].targetOffsetTranslate [x,y,z]	|O| | | | | |
 |.target[].targetOffsetRotate [x,y,z]		|O| | | | | |
 |.target[].targetScaleCompensate			|O| | | | | |
 |.target[].targetInverseScale [x,y,z]		|O| | | | | |
-|.target[].targetScale [x,y,z]				|O| | | |O| |
+|.target[].targetRotatePivot [x,y,z]		|O|O| |O| |O|
+|.target[].targetRotateTranslate [x,y,z]	|O|O| |O| |O|
+|.target[].targetJointOrient [x,y,z]		|O| |O| | | |
+|.target[].targetRotateOrder				|O| |O| | | |
+|.target[].targetRotateCached [x,y,z]		|O| |O| | | |
 
 **other attributes**
 
-|attr/constraint|parent|aim|orient|point|scale|poleVector|
+attributes may be mentioned again here to disambiguate similarly named attributes
+
+|attribute|parent|aim|orient|point|scale|poleVector|
 |:-|:-:|:-:|:-:|:-:|:-:|:-:|
+|.pivotSpace							| | | | | |O|
+|.constraintScaleCompensate				| | | | |O| |
+|.scaleCompensate						| |O|O| | | |
+|.useOldOffsetCalculation				| |O|O| | | |
 |.interpCache							|O| |O| | | |
 |.interpType							|O| | | | | |
 |.rotationDecompositionTarget [x,y,z]	|O| | | | | |
 |.useDecompositionTarget				|O| | | | | |
-|.scaleCompensate						| |O|O| | | |
-|.useOldOffsetCalculation				| |O|O| | | |
-|.worldUpMatrix							| |O| | | | |
-|.worldUpType							| |O| | | | |
-|.worldUpVector [x,y,z]					| |O| | | | |
+
+----
 
 ### parentConstraint
 - .constraintJointOrient [x,y,z]

--- a/notes/mayaConstraintNodes.md
+++ b/notes/mayaConstraintNodes.md
@@ -92,34 +92,34 @@ query flags require `q=True`
 
 **common flags**
 
-|flag|sN|flag type|parent|aim|orient|point|scale|poleVector|
-|:-|:-|:-|:-:|:-:|:-:|:-:|:-:|:-:|
-|name |`n`|query, create, edit					|O|O|O|O|O|O|
-|offset|`o`| query, create, edit				| |O|O|O|O| |
-|layer |`l`|create, edit						|O|O|O|O|O|O|
-|maintainOffset |`mo`|create					|O|O|O|O|O| |
-|remove |`rm`|edit								|O|O|O|O|O|O|
-|targetList |`tl`|query							|O|O|O|O|O|O|
-|weight = 1.0 |`w`|query, create, edit			|O|O|O|O|O|O|
-|weightAliasList |`wal`|query					|O|O|O|O|O|O|
-|skipRotate |`sr`|create, multiuse				|O| | | | | |
-|skipTranslate |`st`|create, multiuse			|O| | | | | |
-|skip|`sk`| create, edit, multiuse				| |O|O|O|O| |
+|flag|sN|query|flag type|parent|aim|orient|point|scale|poleVector|
+|:-|:-|:-:|:-|:-:|:-:|:-:|:-:|:-:|:-:|
+|name |`n`|query| create, edit					|O|O|O|O|O|O|
+|offset|`o`|query| create, edit					| |O|O|O|O| |
+|layer |`l`| |create, edit						|O|O|O|O|O|O|
+|maintainOffset |`mo`| |create					|O|O|O|O|O| |
+|remove |`rm`| |edit							|O|O|O|O|O|O|
+|targetList |`tl`|query| 						|O|O|O|O|O|O|
+|weight = 1.0 |`w`|query| create, edit			|O|O|O|O|O|O|
+|weightAliasList |`wal`|query| 					|O|O|O|O|O|O|
+|skipRotate |`sr`| |create, multiuse			|O| | | | | |
+|skipTranslate |`st`| |create, multiuse			|O| | | | | |
+|skip|`sk`| | create, edit, multiuse			| |O|O|O|O| |
 
 **specific flags**
 
 
-|flag|sN|flag type|parent|aim|orient|point|scale|poleVector|
-|:-|:-|:-|:-:|:-:|:-:|:-:|:-:|:-:|
-|scaleCompensate|`sc`|create, edit				| | | | |O| |
-|createCache |`cc`|edit							|O| |O| | | |
-|deleteCache |`dc`|edit							|O| |O| | | |
-|decompRotationToChild |`dr`|create				|O| | | | | |
-|aimVector|`aim`| query, create, edit			| |O| | | | |
-|upVector|`u`| query, create, edit				| |O| | | | |
-|worldUpObject|`wuo`| query, create, edit		| |O| | | | |
-|worldUpType|`wut`| query, create, edit			| |O| | | | |
-|worldUpVector|`wu`| query, create, edit		| |O| | | | |
+|flag|sN|query|flag type|parent|aim|orient|point|scale|poleVector|
+|:-|:-|:-:|:-|:-:|:-:|:-:|:-:|:-:|:-:|
+|scaleCompensate|`sc`| |create, edit			| | | | |O| |
+|createCache |`cc`| |edit						|O| |O| | | |
+|deleteCache |`dc`| |edit						|O| |O| | | |
+|decompRotationToChild |`dr`| |create			|O| | | | | |
+|aimVector|`aim`|query| create, edit			| |O| | | | |
+|upVector|`u`|query| create, edit				| |O| | | | |
+|worldUpObject|`wuo`|query| create, edit		| |O| | | | |
+|worldUpType|`wut`|query| create, edit			| |O| | | | |
+|worldUpVector|`wu`|query| create, edit			| |O| | | | |
 
 ### attributes
 

--- a/notes/mayaConstraintNodes.md
+++ b/notes/mayaConstraintNodes.md
@@ -71,6 +71,8 @@ attributes of note:
 
 > poleVectorConstraint is a variation on a pointConstraint that is designed explicitly to constrain the pole vector of an ikRPsolver ikHandle to follow one or more target objects
 
+----
+
 # scope reduction
 
 - manually recording all changed values would be overkill, considering most of these values are enumerated according to the transforms involved
@@ -86,6 +88,27 @@ attributes of note:
 
 the `aimConstraint` node will be covered for the sake of completion, although consider using `aimMatrix` first, especially if most of the rig is already maths and matrix driven in the first place
 
+**in summary**:
+- create command
+- check targets(s) and driven objects
+- check where the target(s) constraint weight is connected to
+- `aimConstraint`:
+	- check if `aimVector`, `upVector`, `worldUpType`, `worldUpMatrix`, `worldUpVector` are default values. if there is a change, check if it's connected upstream (if it's connected, skip, otherwise record value and compose `setAttr` command)
+- let the constraint DAG object stay under the driven object (i.e. no reparenting, skip parent checks)
+- skip main addAttr handler
+- skip main setAttr handler
+- skip main connetion handler
+- don't do more than this
+
+**for other handlers**:
+- connection handler:
+	- if any downstream node is of a type of constraint: skip this connection
+- reparenting handler
+	- currently only for transform node handler, but if there ever was a dedicated handler specifically for reparenting: skip this connection
+
+
+----
+
 ## creation command flags
 
 query flags require `q=True`
@@ -95,16 +118,16 @@ query flags require `q=True`
 |flag|sN|query|flag type|parent|aim|orient|point|scale|poleVector|
 |:-|:-|:-:|:-|:-:|:-:|:-:|:-:|:-:|:-:|
 |name |`n`|query| create, edit					|O|O|O|O|O|O|
+|maintainOffset |`mo`| |create					|O|O|O|O|O| |
 |offset|`o`|query| create, edit					| |O|O|O|O| |
 |layer |`l`| |create, edit						|O|O|O|O|O|O|
-|maintainOffset |`mo`| |create					|O|O|O|O|O| |
-|remove |`rm`| |edit							|O|O|O|O|O|O|
 |targetList |`tl`|query| 						|O|O|O|O|O|O|
 |weight = 1.0 |`w`|query| create, edit			|O|O|O|O|O|O|
 |weightAliasList |`wal`|query| 					|O|O|O|O|O|O|
 |skipRotate |`sr`| |create, multiuse			|O| | | | | |
 |skipTranslate |`st`| |create, multiuse			|O| | | | | |
 |skip|`sk`| | create, edit, multiuse			| |O|O|O|O| |
+|remove |`rm`| |edit							|O|O|O|O|O|O|
 
 **specific flags**
 

--- a/source/nodeToPython.py
+++ b/source/nodeToPython.py
@@ -662,16 +662,26 @@ for node in nodeListStage2:
 		getTargetWeightConnection = []
 		getDriven = mc.listConnections(node+'.constraintParentInverseMatrix', s=True, d=False)[0]
 
+		# mc.{constraintType}(parent, parent... , child, mo=True/False)
+
 		setMaintainOffset = False
+		setAimConstraint = ""
 		setSkip = []
 
 		getTargetIndex = mc.getAttr(node+'.target', mi=True) # multiple instances
-		# TODO: check for gap cases (wtf is it doing in a constraint node??)
+		# WARNING: if there is a plug instance, but no connections going into this, getAttr WILL STILL RETURN THIS INDEX
+		# also like why is there an empty instance in a constraint node
+		#	i'm opting for this script to not save the user from this situation and just ignore the gaps
+		#	i mean like maya really does not want users to mess with the order going into constraint nodes, so like off-roading with constraints doesn't sound like a good idea
 		for i in getTargetIndex:
 			# get targets (does not have to be in exact index, so long as it's in order)
-			getTargets.append( mc.listConnections(f"{node}.target[{i}].targetParentMatrix", source=True, destination=False) )
+			queryTargets = mc.listConnections(f"{node}.target[{i}].targetParentMatrix", source=True, destination=False)
+			if queryTargets == None:
+				continue # gap case, skip
+			getTargets.append(queryTargets[0])
+
 			queryTargetWeight = mc.listConnections(f"{node}.target[{i}].targetWeight", s=True, d=False, c=True, p=True)
-			
+
 			# check if targetWeight is connected to command-premade user-defined attribute on self
 			if queryTargetWeight[0].split('.', 1)[0] == queryTargetWeight[1].split('.', 1)[0]: # if true, check where THAT is being connected to
 				# if this connects to itself AGAIN, i am not saving the user from themselves (even if it means that'd be me)

--- a/source/nodeToPython.py
+++ b/source/nodeToPython.py
@@ -383,7 +383,7 @@ for node in checkList:
 		getParent = mc.listRelatives(node, p=True, c=False)[0]
 		nodeList += f"nodeList[{len(nodeListStage2)-1}] = jointList[{jointListIndex}] # joint - {node}"
 		# f'"{node}" # mc.createNode("joint", n={NAME}, p={parentName}, skipSelect=True)'
-		pass	
+		pass
 	
 	#////////////////////////////////////////////////
 	# ikHandle and ikEffector, plus curve for splineIK
@@ -650,6 +650,36 @@ for node in nodeListStage2:
 
 	thisNodeType = mc.nodeType(node)
 	
+	if thisNodeType in nodeTypeUseCommandsConstraint:
+		# the creation command handler for constraints
+		
+		constraintType = thisNodeType # thankfully nodeType of constraint == maya command for constraint
+		# command-agnostic way to query target list
+		getTargetIndex = mc.getAttr(node+'.target', mi=True) # multiple instances
+		getTargets = [] # nodeList strings
+		getTargetWeightConnection = []
+		for i in getTargetIndex:
+			# get targets (does not have to be in exact index, so long as it's in order)
+			getTargets.append( mc.listConnections(f"{node}.target[{i}].targetParentMatrix", source=True, destination=False) )
+			queryTargetWeight = mc.listConnections(f"{node}.target[{i}].targetWeight", s=True, d=False, c=True, p=True)
+			
+			# check if targetWeight is connected to command-premade user-defined attribute on self
+			if queryTargetWeight[0].split('.', 1)[0] == queryTargetWeight[1].split('.', 1)[0]: # if true, check where THAT is being connected to
+				# if this connects to itself AGAIN, i am not saving the user from themselves (even if it means that'd be me)
+				# reminder that this script will not be making addAttr commands for constraint nodes
+				getTargetWeightConnection.append( mc.listConnections(queryTargetWeight[1], s=True, d=False, plugs=True)[0] )
+			else: # it's connected to something else directly, get connection
+				getTargetWeightConnection.append( queryTargetWeight[1] )
+			
+
+			# check if target is in nodeList
+			# if target is not in nodelist.... just pass the name verbatim
+				
+
+
+		constraintList.append(f"mc.{constraintType}()") 
+		continue # do not use other handlers, go to next in stage 2 list
+
 	"""
 	////////////////////////////////////////////////////////
 	mc.parent("  reparenting objects on the DAG hierachy  ")


### PR DESCRIPTION
constraint node handler:
- simple crawl for drivers/targets and driven/constrained
- simple check for connections to driver/target weights
- deliberately non-extensive, due to complexities and difficulty covering off-road use of the node

see scope at `notes/mayaconstraintNodes.md`

other adjustments to script
- first pass on troubleshooting: script should run, but WILL contain errors